### PR TITLE
Added missing param to addLayer function

### DIFF
--- a/netflow/js/core/netflow.js
+++ b/netflow/js/core/netflow.js
@@ -43,9 +43,9 @@ function setup() {
     this.width = 0;
     this.training = null;
 
-    this.addLayer = function (n){
+    this.addLayer = function (n, activation){
         
-        var layer = new Layer(n);
+        var layer = new Layer(n, activation);
         layer.type = "OUTPUT";
         if(this.size == 0)
             layer.type = "INPUT";


### PR DESCRIPTION
There is an example in README.md for adding activation function. But activation function was accepting only one parameter.

"net.addLayer(2, ReLu); // hidden with activation function"